### PR TITLE
feat: Added detent sheet

### DIFF
--- a/Examples/SingleNavigator/01-SingleBasic/SingleBasic/Page/Home/HomeView.swift
+++ b/Examples/SingleNavigator/01-SingleBasic/SingleBasic/Page/Home/HomeView.swift
@@ -42,6 +42,17 @@ struct HomeView: View {
         Text("open Page 2 as Sheet")
           .foregroundColor(.purple)
       }
+      
+      Button(action: {
+        if #available(iOS 15.0, *) {
+          navigator.detentSheet(linkItem: .init(pathList: ["page1", "page2"]), isAnimated: true, configuration: .default)
+        } else {
+          navigator.sheet(linkItem: .init(pathList: ["page1", "page2"]), isAnimated: true)
+        }
+      }) {
+        Text("open Page 2 as Detent Sheet")
+          .foregroundColor(.purple)
+      }
 
       Button(action: {
         navigator.fullSheet(linkItem: .init(pathList: ["page1", "page2"]), isAnimated: true, prefersLargeTitles: true)

--- a/Sources/LinkNavigator/Core/Core/DetentConfiguration.swift
+++ b/Sources/LinkNavigator/Core/Core/DetentConfiguration.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+@available(iOS 15.0, *)
+public struct DetentConfiguration {
+  
+  public static let `default` = DetentConfiguration(detents: [.medium(), .large()])
+  
+  public let detents: [UISheetPresentationController.Detent]
+  public let cornerRadius: CGFloat?
+  public let largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
+  public let prefersScrollingExpandsWhenScrolledToEdge: Bool
+  public let prefersGrabberVisible: Bool
+  public let prefersEdgeAttachedInCompactHeight: Bool
+  public let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
+  public let selectedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
+  
+  /// Initializes a new DetentConfiguration.
+  ///
+  /// - Parameters:
+  ///   - detents: An array of `UISheetPresentationController.Detent` defining the sizes of the sheet.
+  ///   - cornerRadius: An optional `CGFloat` specifying the corner radius of the sheet.
+  ///   - largestUndimmedDetentIdentifier: An optional detent identifier specifying the largest undimmed size.
+  ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value indicating if scrolling should expand the sheet.
+  ///   - prefersGrabberVisible: A Boolean value indicating if the grabber should be visible.
+  ///   - prefersEdgeAttachedInCompactHeight: A Boolean value indicating if the sheet should be edge-attached in compact height.
+  ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value indicating if the sheet's width should follow the preferred content size when edge-attached.
+  ///   - selectedDetentIdentifier: An optional detent identifier specifying the currently selected detent.
+  public init(
+    detents: [UISheetPresentationController.Detent],
+    cornerRadius: CGFloat? = nil,
+    largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
+    prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
+    prefersGrabberVisible: Bool = false,
+    prefersEdgeAttachedInCompactHeight: Bool = false,
+    widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+    selectedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil
+  ) {
+    self.detents = detents
+    self.cornerRadius = cornerRadius
+    self.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier
+    self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
+    self.prefersGrabberVisible = prefersGrabberVisible
+    self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
+    self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
+    self.selectedDetentIdentifier = selectedDetentIdentifier
+  }
+}

--- a/Sources/LinkNavigator/Core/Core/SingleLinkNavigator.swift
+++ b/Sources/LinkNavigator/Core/Core/SingleLinkNavigator.swift
@@ -140,7 +140,20 @@ extension SingleLinkNavigator {
   private func _sheet(linkItem: LinkItem, isAnimated: Bool) {
     sheetOpen(item: linkItem, isAnimated: isAnimated)
   }
-
+  
+  /// Opens a sheet with the specified link item and an option to animate the presentation.
+  ///
+  /// - Parameters:
+  ///   - linkItem: An object representing the item to be presented in the sheet, can be a `String` or a dictionary with `String` keys and values as `ItemValue`.
+  ///   - isAnimated: A boolean to indicate if the presentation should be animated.
+  ///   - configuration: A `DetentConfiguration` object that defines the appearance and behavior of the sheet.
+  ///
+  /// - Available from iOS 15.0 and later.
+  @available(iOS 15.0, *)
+  private func _detentSheet(linkItem: LinkItem, isAnimated: Bool, configuration: DetentConfiguration) {
+      detentSheetOpen(item: linkItem, isAnimated: isAnimated, configuration: configuration)
+    }
+  
   /// Opens a full-screen sheet with options for animation and large titles.
   ///
   /// - Parameters:
@@ -401,6 +414,40 @@ extension SingleLinkNavigator {
       subController = newController
     }
   }
+  
+  @available(iOS 15.0, *)
+  public func detentSheetOpen(
+    item: LinkItem,
+    isAnimated: Bool,
+    configuration: DetentConfiguration)
+  {
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      guard let rootController else { return }
+
+      rootController.dismiss(animated: true)
+      let newController = UINavigationController()
+      
+      if let sheetPresentationController = newController.sheetPresentationController {
+        sheetPresentationController.detents = configuration.detents
+        sheetPresentationController.preferredCornerRadius = configuration.cornerRadius
+        sheetPresentationController.largestUndimmedDetentIdentifier = configuration.largestUndimmedDetentIdentifier
+        sheetPresentationController.prefersScrollingExpandsWhenScrolledToEdge = configuration.prefersScrollingExpandsWhenScrolledToEdge
+        sheetPresentationController.prefersGrabberVisible = configuration.prefersGrabberVisible
+        sheetPresentationController.prefersEdgeAttachedInCompactHeight = configuration.prefersEdgeAttachedInCompactHeight
+        sheetPresentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = configuration.widthFollowsPreferredContentSizeWhenEdgeAttached
+        sheetPresentationController.selectedDetentIdentifier = configuration.selectedDetentIdentifier
+      }
+
+      newController.setViewControllers(
+        navigationBuilder.build(item: item),
+        animated: false)
+
+      rootController.present(newController, animated: isAnimated)
+      
+      subController = newController
+    }
+  }
 
   // MARK: Private
 
@@ -434,6 +481,15 @@ extension SingleLinkNavigator: LinkNavigatorProtocol {
 
   public func sheet(linkItem: LinkItem, isAnimated: Bool) {
     _sheet(linkItem: linkItem, isAnimated: isAnimated)
+  }
+  
+  @available(iOS 15.0, *)
+  public func detentSheet(
+    linkItem: LinkItem,
+    isAnimated: Bool,
+    configuration: DetentConfiguration
+  ) {
+    _detentSheet(linkItem: linkItem, isAnimated: isAnimated, configuration: configuration)
   }
 
   public func fullSheet(linkItem: LinkItem, isAnimated: Bool, prefersLargeTitles: Bool?) {

--- a/Sources/LinkNavigator/Core/Protocol/LinkNavigatorProtocol.swift
+++ b/Sources/LinkNavigator/Core/Protocol/LinkNavigatorProtocol.swift
@@ -25,7 +25,22 @@ public protocol LinkNavigatorProtocol {
   ///   - linkItem: The link item to present.
   ///   - isAnimated: A Boolean value that determines whether the presentation is animated.
   func sheet(linkItem: LinkItem, isAnimated: Bool)
-
+  
+  /// Presents a sheet with the given link item.
+  ///
+  /// - Parameters:
+  ///   - linkItem: The link item to present.
+  ///   - isAnimated: A Boolean value that determines whether the presentation is animated.
+  ///   - configuration: A `DetentConfiguration` object that defines the appearance and behavior of the sheet.
+  ///
+  /// - Available from iOS 15.0 and later.
+  @available(iOS 15.0, *)
+  func detentSheet(
+      linkItem: LinkItem,
+      isAnimated: Bool,
+      configuration: DetentConfiguration
+  )
+  
   /// Presents a full sheet with the given link item.
   ///
   /// - Parameters:

--- a/Sources/LinkNavigator/Test/SingleLinkNavigatorMock.swift
+++ b/Sources/LinkNavigator/Test/SingleLinkNavigatorMock.swift
@@ -118,6 +118,11 @@ extension SingleLinkNavigatorMock: LinkNavigatorProtocol {
   public func sheet(linkItem _: LinkItem, isAnimated _: Bool) {
     event.sheet += 1
   }
+  
+  @available(iOS 15.0, *)
+  public func detentSheet(linkItem: LinkItem, isAnimated: Bool, configuration: DetentConfiguration) {
+    event.sheet += 1
+  }
 
   public func fullSheet(linkItem _: LinkItem, isAnimated _: Bool, prefersLargeTitles _: Bool?) {
     event.fullSheet += 1


### PR DESCRIPTION
## Sheet에 detent를 설정할 수 있는 옵션을 추가하였습니다.

사용방법은 LinkNavigatorProtocol > detentSheet() 또는 SingleLinkNavigator > _detentSheet() 의 주석 도큐멘트에서 확인할 수 있습니다.

또한 01-SingleBasic 예제의 HomeView에서 아래와 같이 사용 예제를 확인할 수 있습니다.
```swift
      Button(action: {
        if #available(iOS 15.0, *) {
          navigator.detentSheet(
            linkItem: .init(pathList: ["page1", "page2"]),
            isAnimated: true,
            detents: [.medium(), .large()],
            cornerRadius: 24,
            largestUndimmedDetentIdentifier: .none,
            prefersScrollingExpandsWhenScrolledToEdge: true,
            prefersGrabberVisible: false,
            prefersEdgeAttachedInCompactHeight: true,
            widthFollowsPreferredContentSizeWhenEdgeAttached: false,
            selectedDetentIdentifier: .none)
        } else {
          navigator.sheet(linkItem: .init(pathList: ["page1", "page2"]), isAnimated: true)
        }
      }) {
        Text("open Page 2 as Detent Sheet")
          .foregroundColor(.purple)
      }
```

</br>

## 01-SingleBasic 동작 예시

![detented_sheet](https://github.com/user-attachments/assets/688676c9-e770-43ef-9411-1a90c0b0451c)


</br>

## 도전과제

코드에서 보시다시피 detentSheet은 detent에서 사용할 수 있는 옵션을 많은 파라미터로 받고있습니다.
그러나 꼭 필요하지 않은 옵션이 많아서 default value를 제공하는 편이 LinkNavigator를 사용하는 클라이언트 입장에서 사용성 증대 및 혼동을 피할 수 있지 않을까 생각합니다.
하지만 parameter default value를 제공하기 위해서 detentSheet만 LinkNavigatorProtocol을 extension 하여 제공하기에 기존 protocol에 정의된 함수들에 대한 default value 제공 일관성을 해 하는 것 같아서 유지보수 측면에서도 고려해 보아야 할 사항 같습니다.
